### PR TITLE
Fix mobile horizontal scroll

### DIFF
--- a/src/styles/Page.scss
+++ b/src/styles/Page.scss
@@ -1,3 +1,8 @@
+html,
+body {
+    overflow-x: hidden;
+}
+
 body {
     margin: 0;
     font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
## Summary
- prevent horizontal scroll by hiding overflow on `html` and `body`

## Testing
- `npm run build`