### PR TITLE
Enable smooth scroll to top via logo

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -48,7 +48,8 @@ const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
   const scrollToTop = () => {
     setActiveSection(sections[0].id);
     closeMenu();
-    window.scrollTo({
+    const scrollEl = document.scrollingElement || document.documentElement;
+    scrollEl.scrollTo({
       top: 0,
       behavior: 'smooth',
     });

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -24,7 +24,7 @@ interface NavbarProps {
  */
 const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { sections } = useSectionsContext();
+  const { sections, setActiveSection } = useSectionsContext();
   const { locale } = useLanguage();
   const switchTo = locale === 'es' ? 'en' : 'es';
 
@@ -46,6 +46,7 @@ const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
    * Scrolls the window to the top smoothly.
    */
   const scrollToTop = () => {
+    setActiveSection(sections[0].id);
     window.scrollTo({
       top: 0,
       behavior: 'smooth',

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -47,6 +47,7 @@ const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
    */
   const scrollToTop = () => {
     setActiveSection(sections[0].id);
+    closeMenu();
     window.scrollTo({
       top: 0,
       behavior: 'smooth',
@@ -56,8 +57,19 @@ const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
   return (
     <>
       <nav className="navbar">
-        <div className="navbar__logo">
-          <Image loading="eager" src="/images/logo.webp" alt={getUiText('logoAlt', locale)} width={90} height={40} onClick={scrollToTop} style={{ cursor: 'pointer' }} />
+        <div
+          className="navbar__logo"
+          role="button"
+          aria-label={getUiText('logoAlt', locale)}
+          onClick={scrollToTop}
+        >
+          <Image
+            loading="eager"
+            src="/images/logo.webp"
+            alt={getUiText('logoAlt', locale)}
+            width={90}
+            height={40}
+          />
         </div>
         <div className="navbar__menu-icon" onClick={toggleMenu}>
           <div className="navbar__menu-icon-separator" />

--- a/src/styles/Navbar.scss
+++ b/src/styles/Navbar.scss
@@ -19,6 +19,7 @@
     align-items: center;
     justify-content: center;
     height: 100%;
+    cursor: pointer;
   }
 
   &__menu-icon {


### PR DESCRIPTION
## Summary
- allow the Navbar logo to activate the first section and smoothly scroll to the top

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eccb2d66883239f8017e4835e6476