### PR TITLE
Add SVG flag icons for language switcher

### DIFF
--- a/src/components/Flag/Flag.tsx
+++ b/src/components/Flag/Flag.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { Locale } from '@/context/Language';
+
+interface FlagProps {
+  locale: Locale;
+  width?: number;
+  height?: number;
+}
+
+const Flag: React.FC<FlagProps> = ({ locale, width = 24, height = 16 }) => {
+  if (locale === 'es') {
+    return (
+      <svg viewBox="0 0 18 12" width={width} height={height} xmlns="http://www.w3.org/2000/svg">
+        <rect width="18" height="12" fill="#C60B1E" />
+        <rect y="3" width="18" height="6" fill="#FFC400" />
+      </svg>
+    );
+  }
+  // default to United Kingdom flag for 'en'
+  return (
+    <svg viewBox="0 0 18 12" width={width} height={height} xmlns="http://www.w3.org/2000/svg">
+      <rect width="18" height="12" fill="#012169" />
+      <path d="M0 0L18 12M18 0L0 12" stroke="#FFF" strokeWidth="2.4" />
+      <path d="M0 0L18 12M18 0L0 12" stroke="#C8102E" strokeWidth="1.2" />
+      <path d="M9 0v12M0 6h18" stroke="#FFF" strokeWidth="3" />
+      <path d="M9 0v12M0 6h18" stroke="#C8102E" strokeWidth="1.5" />
+    </svg>
+  );
+};
+
+export default Flag;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -10,8 +10,9 @@
 import React from 'react';
 import '@/styles/Menu.scss';
 import { useSectionsContext } from '@/context/Sections';
-import { useLanguage } from '@/context/Language';
+import { useLanguage, Locale } from '@/context/Language';
 import Link from 'next/link';
+import Flag from '@/components/Flag/Flag';
 import type { MenuProps } from '@/interfaces/props';
 
 /* 
@@ -37,7 +38,9 @@ const Menu: React.FC<MenuProps> = ({ onSectionClick }) => {
         ))}
       </ul>
       <div className="menu__lang">
-        <Link href={`/${switchTo}`}>{switchTo.toUpperCase()}</Link>
+        <Link href={`/${switchTo}`}>
+          <Flag locale={switchTo as Locale} />
+        </Link>
       </div>
     </div>
   );

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -9,6 +9,8 @@
 import React, { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import Flag from '@/components/Flag/Flag';
+import type { Locale } from '@/context/Language';
 import '@/styles/Navbar.scss';
 import { useSectionsContext } from '@/context/Sections';
 import { useLanguage } from '@/context/Language';
@@ -73,7 +75,9 @@ const Navbar: React.FC<NavbarProps> = ({ onSectionClick }) => {
             ))}
           </ul>
           <div className="navbar__menu-lang">
-            <Link href={`/${switchTo}`}>{switchTo.toUpperCase()}</Link>
+            <Link href={`/${switchTo}`}>
+              <Flag locale={switchTo as Locale} />
+            </Link>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- add `Flag` component to render Spanish or UK flag SVGs
- show flags in Navbar and Menu language selectors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eccde01388323b16473ca16bfd5fc